### PR TITLE
Fix - Allow for multiple views

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "designory front end developer take home test boilerplate",
   "scripts": {
-    "views": "cpx ./src/views/*.html ./dist --verbose",
+    "views": "cpx \"./src/views/*.html\" ./dist --verbose",
     "watch-views": "npm run views -- --watch",
     "scripts": "babel ./src/scripts/ --verbose --out-dir ./dist/js/ --source-maps --presets=@babel/preset-env",
     "watch-scripts": "npm run scripts -- --watch",


### PR DESCRIPTION
If we have more than one HTML file, **cpx** exits early:

```
$ npm run views

> cpx ./src/views/*.html ./dist --verbose

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! fed-takehome-boilerplate@1.0.0 views: `cpx ./src/views/*.html ./dist --verbose`
npm ERR! Exit status 1
```

Wrapping our glob string in quotes seems to fix the issue.